### PR TITLE
Explicitly cast to long tensors for indices in C&W attack

### DIFF
--- a/advertorch/attacks/carlini_wagner.py
+++ b/advertorch/attacks/carlini_wagner.py
@@ -111,9 +111,9 @@ class CarliniWagnerL2Attack(Attack, LabelMixin):
         if is_logits:
             output = output.detach().clone()
             if self.targeted:
-                output[torch.arange(len(label)), label] -= self.confidence
+                output[torch.arange(len(label)).long(), label] -= self.confidence
             else:
-                output[torch.arange(len(label)), label] += self.confidence
+                output[torch.arange(len(label)).long(), label] += self.confidence
             pred = torch.argmax(output, dim=1)
         else:
             pred = output


### PR DESCRIPTION
In the `_is_successful()` function, `torch.arange` raises an exception
saying that the indices should be long or byte tensors on PyTorch 0.4.1.
Therefore, explicit casting to `long` tensors is required