### PR TITLE
L2CarliniWagner Clamping Rectification

### DIFF
--- a/advertorch/attacks/carlini_wagner.py
+++ b/advertorch/attacks/carlini_wagner.py
@@ -144,7 +144,7 @@ class CarliniWagnerL2Attack(Attack, LabelMixin):
 
     def _get_arctanh_x(self, x):
         result = clamp((x - self.clip_min) / (self.clip_max - self.clip_min),
-                       min=self.clip_min, max=self.clip_max) * 2 - 1
+                       min=0., max=1.) * 2 - 1
         return torch_arctanh(result * ONE_MINUS_EPS)
 
     def _update_if_smaller_dist_succeed(


### PR DESCRIPTION
 In the arctanh computation, (x-(min(x))/(max(x)-min(x)) is defined between 0 and 1 not min(x) and max(x). Consequently, the clamping should depend on clip_min and clip_max. 
It induces errors on attacks computed on inputs between [-0.5, 0.5] for instance.