### PR TITLE
Make LinfFABAttack backward compatible

### DIFF
--- a/advertorch/attacks/fast_adaptive_boundary.py
+++ b/advertorch/attacks/fast_adaptive_boundary.py
@@ -68,6 +68,11 @@ class FABAttack(Attack, LabelMixin):
 
     def check_shape(self, x):
         return x if len(x.shape) > 0 else x.unsqueeze(0)
+    
+    def flip(self, x, dim):
+        dim = x.dim() + dim if dim < 0 else dim
+        indices = torch.arange(x.size(dim)-1, -1, -1, dtype=torch.long, device=x.device, requires_grad=x.requires_grad)
+        return x.index_select(dim, indices)
 
     def get_diff_logits_grads_batch(self, imgs, la):
         im = imgs.clone().requires_grad_()
@@ -107,14 +112,14 @@ class FABAttack(Attack, LabelMixin):
         a -= a * (1 - c5)
 
         p = torch.ones(t.shape).to(self.device) * c5 - t * (2 * c5 - 1)
-        indp = torch.argsort(p, dim=1)
+        _, indp = torch.sort(p, dim=1)
 
         b = b - (w * t).sum(1)
         b0 = (w * d).sum(1)
         b1 = b0.clone()
 
         counter = 0
-        indp2 = indp.unsqueeze(-1).flip(dims=(1, 2)).squeeze()
+        indp2 = self.flip(self.flip(indp.unsqueeze(-1), 1), 2).squeeze()
         u = torch.arange(0, w.shape[0])
         ws = w[u.unsqueeze(1), indp2]
         bs2 = - ws * d[u.unsqueeze(1), indp2]
@@ -151,7 +156,7 @@ class FABAttack(Attack, LabelMixin):
         lb = lb.long()
         counter2 = 0
 
-        if c_l.nelement != 0:
+        if c_l.nelement() != 0:
             lmbd_opt = (torch.max((b[c_l] - sb[c_l, -1]) / (-s[c_l, -1]),
                                   torch.zeros(sb[c_l, -1].shape)
                                   .to(self.device))).unsqueeze(-1)

--- a/advertorch/utils.py
+++ b/advertorch/utils.py
@@ -40,6 +40,21 @@ def torch_allclose(x, y, rtol=1.e-5, atol=1.e-8):
                        rtol=rtol, atol=atol)
 
 
+def single_dim_flip(x, dim):
+    dim = x.dim() + dim if dim < 0 else dim
+    indices = torch.arange(
+        x.size(dim) - 1, -1, -1,
+        dtype=torch.long, device=x.device, requires_grad=x.requires_grad)
+    # TODO: do we need requires_grad???
+    return x.index_select(dim, indices)
+
+
+def torch_flip(x, dims):
+    for dim in dims:
+        x = single_dim_flip(x, dim)
+    return x
+
+
 def replicate_input(x):
     return x.detach().clone()
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -18,6 +18,7 @@ from advertorch.utils import MNIST_MEAN
 from advertorch.utils import MNIST_STD
 from advertorch.utils import NormalizeByChannelMeanStd
 from advertorch.utils import PerImageStandardize
+from advertorch.utils import torch_flip
 from advertorch_examples.utils import bchw2bhwc
 from advertorch_examples.utils import bhwc2bchw
 
@@ -80,3 +81,8 @@ def test_per_image_standardization():
         warnings.simplefilter("ignore")
         tf_scaled = _run_tf_per_image_standardization(imgs)
     assert np.abs(pt_scaled - tf_scaled).max() < 0.001
+
+
+def test_flip():
+    x = torch.randn(4, 5, 6, 7)
+    assert (torch_flip(x, dims=(1, 2)) == torch.flip(x, dims=(1, 2))).all()


### PR DESCRIPTION
The current implementation has `argsort()` and `flip()` which are available only in PyTorch 1.x+ The changes therefore include using the older versions of these functions. Moreover, the `flip()` function is implemented as a method for `FABAttack`, maybe we can include this as a method in `advertorch.utils` as well.

While I've tested the results for small number of iterations and restarts. I would still like if anybody can try for higher number of restarts and match results on TRADES.