### PR TITLE
add simple spatial transform attack #80

### DIFF
--- a/advertorch/attacks/__init__.py
+++ b/advertorch/attacks/__init__.py
@@ -39,6 +39,7 @@ from .localsearch import SinglePixelAttack
 from .localsearch import LocalSearchAttack
 
 from .spatial import SpatialTransformAttack
+from .spatial2 import SpatialTransformAttack2
 
 from .jsma import JacobianSaliencyMapAttack
 from .jsma import JSMA

--- a/advertorch/attacks/spatial2.py
+++ b/advertorch/attacks/spatial2.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2018-present, Royal Bank of Canada.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from itertools import product, repeat
+
+import torch
+import numpy as np
+from .base import Attack
+from .base import LabelMixin
+
+_MESHGRIDS = {}
+
+
+def make_meshgrid(x):
+    bs, _, _, dim = x.shape
+    device = x.get_device()
+    key = (dim, bs, device)
+    if key in _MESHGRIDS:
+        return _MESHGRIDS[key]
+    space = torch.linspace(-1, 1, dim)
+    meshgrid = torch.meshgrid([space, space])
+    gridder = torch.cat([meshgrid[1][..., None],
+                         meshgrid[0][..., None]], dim=2)
+    grid = gridder[None, ...].repeat(bs, 1, 1, 1)
+    ones = torch.ones(grid.shape[:3] + (1,))
+    final_grid = torch.cat([grid, ones], dim=3)
+    expanded_grid = final_grid[..., None]
+    _MESHGRIDS[key] = expanded_grid
+    return expanded_grid
+
+
+def unif(size, mini, maxi):
+    args = {"from": mini, "to": maxi}
+    return torch.FloatTensor(size=size).uniform_(**args)
+
+
+def make_slice(a, b, c):
+    to_cat = [a[None, ...], b[None, ...], c[None, ...]]
+    return torch.cat(to_cat, dim=0)
+
+
+def make_mats(rots, txs, w, h):
+    # rots: degrees
+    # txs: % of image dim
+    rots = rots * 0.01745327778  # deg to rad
+    txs = txs * 2
+    cosses = torch.cos(rots)
+    sins = torch.sin(rots)
+    top_slice = make_slice(cosses, -sins, txs[:, 0])[None, ...].permute(
+        [2, 0, 1])
+    bot_slice = make_slice(sins, cosses, txs[:, 1])[None, ...].permute(
+        [2, 0, 1])
+    mats = torch.cat([top_slice, bot_slice], dim=1)
+    mats = mats[:, None, None, :, :]
+    mats = mats.repeat(1, w, h, 1, 1)
+    return mats
+
+
+def transform(x, rots, txs):
+    assert x.shape[2] == x.shape[3]
+    w = x.shape[2]
+    h = x.shape[3]
+    device = x.device
+    
+    with torch.no_grad():
+        meshgrid = make_meshgrid(x).to(device)
+        tfm_mats = make_mats(rots, txs, w, h).to(device)
+        new_coords = torch.matmul(tfm_mats, meshgrid)
+        new_coords = new_coords.squeeze_(-1)
+        new_image = torch.nn.functional.grid_sample(x, new_coords,
+                                                    align_corners=False)
+        return new_image
+
+
+class SpatialTransformAttack2(Attack, LabelMixin):
+    """
+    Spatially Transformed Attack (Engstrom et al. 2019)
+    http://proceedings.mlr.press/v97/engstrom19a.html
+
+    :param predict: forward pass function.
+    :param spatial_constraint: max rot and max trans.
+    :param num_rot: the number of rotation direction grid search
+    :param num_trans: the number of translation direction grid search
+    :param random_tries: the number of random search
+    :param attack_type: attack search type random|grid
+    :param loss_fn: loss function
+    :param clip_min: minimum value per input dimension.
+    :param clip_max: maximum value per input dimension.
+    :param targeted: if the attack is targeted
+    """
+    
+    def __init__(self, predict, spatial_constraint={'rot': 30, 'trans': 0.1},
+                 num_rot=31, num_trans=5, random_tries=10,
+                 attack_type='random', loss_fn=None,
+                 clip_min=0.0, clip_max=1.0, targeted=False):
+        super(SpatialTransformAttack2, self).__init__(
+            predict, loss_fn, clip_min, clip_max)
+        self.predict = predict
+        self.attack_type = attack_type
+        self.targeted = targeted
+        self.loss_fn = loss_fn
+        if self.loss_fn is None:
+            self.loss_fn = torch.nn.CrossEntropyLoss(reduction="sum")
+        self.spatial_constraint = [spatial_constraint['trans'],
+                                   spatial_constraint['trans'],
+                                   spatial_constraint['rot']]
+        if self.attack_type == 'grid':
+            self.granularity = [num_trans, num_trans, num_rot]
+        elif self.attack_type == 'random':
+            self.random_tries = random_tries
+    
+    def perturb(self, x_nat, y=None):
+        x_nat, y = self._verify_and_process_inputs(x_nat, y)
+        if self.attack_type == 'grid':
+            return self.perturb_grid(x_nat, y, -1)
+        elif self.attack_type == 'random':
+            return self.perturb_grid(x_nat, y, self.random_tries)
+        else:
+            raise NotImplementedError()
+    
+    def perturb_grid(self, x_nat, y, random_tries=-1):
+        device = x_nat.device
+        n = len(x_nat)
+        if random_tries > 0:
+            # subsampling this list from the grid is a bad idea, instead we
+            # will randomize each example from the full continuous range
+            grid = [(42, 42, 42) for _ in range(random_tries)]  # dummy list
+        else:  # exhaustive grid
+            grid = product(*list(np.linspace(-ll, ll, num=g)
+                                 for ll, g in zip(self.spatial_constraint,
+                                                  self.granularity)))
+        worst_x = x_nat.clone()
+        worst_t = torch.zeros([n, 3]).to(device)
+        max_xent = torch.zeros(n).to(device)
+        all_correct = torch.ones(n, dtype=torch.bool).to(device)
+        if hasattr(self.loss_fn, 'reduction'):
+            self.org_reduction = self.loss_fn.reduction
+            if self.loss_fn.reduction != 'none':
+                self.loss_fn.reduction = 'none'
+        else:
+            print('loss_fn has been replaced by torch.nn.CrossEntropyLoss '
+                  'because reduction none is not available. '
+                  'If you want to use custom loss, '
+                  'please implement reduction=none')
+            self.loss_fn = torch.nn.CrossEntropyLoss(reduction="none")
+        
+        for tx, ty, r in grid:
+            if random_tries > 0:
+                # randomize each example separately
+                t = np.stack([np.random.uniform(-ll, ll, n) for ll in
+                              self.spatial_constraint], axis=1)
+            else:
+                t = np.stack(list(repeat([tx, ty, r], n)))
+            x = x_nat
+            t = torch.from_numpy(t).type(torch.float32).to(device)
+            x = transform(x, t[:, 2], t[:, :2])
+            with torch.no_grad():
+                logits = self.predict(x)
+            # get the index of the max log-probability
+            pred = logits.detach().max(1)[1]
+            cur_correct = pred.eq(y)
+            if self.targeted:
+                cur_xent = -self.loss_fn(logits, y)  # Reverse the sign
+            else:
+                cur_xent = self.loss_fn(logits, y)
+            
+            # Select indices to update: we choose the misclassified
+            # transformation of maximum xent (or just highest xent
+            # if everything else if correct).
+            idx = (cur_xent > max_xent) & (cur_correct == all_correct)
+            idx = idx | (cur_correct < all_correct)
+            max_xent = torch.max(cur_xent, max_xent)
+            all_correct = cur_correct & all_correct
+            idx = idx.unsqueeze(-1)  # shape (bsize, 1)
+            worst_t = torch.where(idx, t, worst_t)  # shape (bsize, 3)
+            idx = idx.unsqueeze(-1)
+            idx = idx.unsqueeze(-1)  # shape (bsize, 1, 1, 1)
+            worst_x = torch.where(idx, x, worst_x, )  # shape (bsize, w, h, c)
+        if hasattr(self, 'org_reduction'):
+            self.loss_fn.reduction = self.org_reduction
+        return worst_x

--- a/advertorch/test_utils.py
+++ b/advertorch/test_utils.py
@@ -13,6 +13,7 @@ import torch.nn.functional as F
 from advertorch.attacks import LocalSearchAttack
 from advertorch.attacks import SinglePixelAttack
 from advertorch.attacks import SpatialTransformAttack
+from advertorch.attacks import SpatialTransformAttack2
 from advertorch.attacks import JacobianSaliencyMapAttack
 from advertorch.attacks import LBFGSAttack
 from advertorch.attacks import CarliniWagnerL2Attack
@@ -243,6 +244,7 @@ general_input_attacks = [
 
 image_only_attacks = [
     SpatialTransformAttack,
+    SpatialTransformAttack2,
     LocalSearchAttack,
 ]
 
@@ -258,6 +260,7 @@ label_attacks = [
     LBFGSAttack,
     JacobianSaliencyMapAttack,
     SpatialTransformAttack,
+    SpatialTransformAttack2,
     DDNL2Attack,
     SparseL1DescentAttack,
     L1PGDAttack,

--- a/advertorch_examples/attack_benchmarks/benchmark_spatial_transform.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_spatial_transform.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2018-present, Royal Bank of Canada and other authors.
+# See the AUTHORS.txt file for a list of contributors.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#
+#
+# Automatically generated benchmark report (screen print of running this file)
+#
+# sysname: Linux
+# release: 4.15.0-111-generic
+# version: #112-Ubuntu SMP Thu Jul 9 20:32:34 UTC 2020
+# machine: x86_64
+# python: 3.7.3
+# torch: 1.6.0.dev20200402+cu101
+# torchvision: 0.6.0.dev20200402+cu101
+# advertorch: 0.2.3
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 0.0, 'trans': 0.0}
+#                random_tries=1
+#                attack_type=random
+#                num_rot=1
+#                num_trans=1
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test, 10000 samples
+# model: MNIST LeNet5 standard training
+# accuracy: 98.89%
+# attack success rate: 1.16%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 30, 'trans': 0.10714285714285714}
+#                random_tries=10
+#                attack_type=grid
+#                num_rot=31
+#                num_trans=5
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test, 10000 samples
+# model: MNIST LeNet5 standard training
+# accuracy: 98.89%
+# attack success rate: 99.98%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 30, 'trans': 0.10714285714285714}
+#                random_tries=10
+#                attack_type=random
+#                num_rot=31
+#                num_trans=5
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test, 10000 samples
+# model: MNIST LeNet5 standard training
+# accuracy: 98.89%
+# attack success rate: 75.4%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 30, 'trans': 0.10714285714285714}
+#                random_tries=50
+#                attack_type=random
+#                num_rot=31
+#                num_trans=5
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test, 10000 samples
+# model: MNIST LeNet5 standard training
+# accuracy: 98.89%
+# attack success rate: 95.93%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 0.0, 'trans': 0.0}
+#                random_tries=1
+#                attack_type=random
+#                num_rot=1
+#                num_trans=1
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test, 10000 samples
+# model: MNIST LeNet 5 PGD training according to Madry et al. 2018
+# accuracy: 98.64%
+# attack success rate: 1.4%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 30, 'trans': 0.10714285714285714}
+#                random_tries=10
+#                attack_type=grid
+#                num_rot=31
+#                num_trans=5
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test, 10000 samples
+# model: MNIST LeNet 5 PGD training according to Madry et al. 2018
+# accuracy: 98.64%
+# attack success rate: 99.99%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 30, 'trans': 0.10714285714285714}
+#                random_tries=10
+#                attack_type=random
+#                num_rot=31
+#                num_trans=5
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test, 10000 samples
+# model: MNIST LeNet 5 PGD training according to Madry et al. 2018
+# accuracy: 98.64%
+# attack success rate: 70.62%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 30, 'trans': 0.10714285714285714}
+#                random_tries=50
+#                attack_type=random
+#                num_rot=31
+#                num_trans=5
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test, 10000 samples
+# model: MNIST LeNet 5 PGD training according to Madry et al. 2018
+# accuracy: 98.64%
+# attack success rate: 94.12%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 0.0, 'trans': 0.0}
+#                random_tries=1
+#                attack_type=random
+#                num_rot=1
+#                num_trans=1
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: cifar10_test, 10000 samples
+# model: CIFAR10 ResNet18 standard training
+# accuracy: 94.64%
+# attack success rate: 7.05%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 30, 'trans': 0.10714285714285714}
+#                random_tries=10
+#                attack_type=grid
+#                num_rot=31
+#                num_trans=5
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: cifar10_test, 10000 samples
+# model: CIFAR10 ResNet18 standard training
+# accuracy: 94.64%
+# attack success rate: 86.71%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 30, 'trans': 0.10714285714285714}
+#                random_tries=10
+#                attack_type=random
+#                num_rot=31
+#                num_trans=5
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: cifar10_test, 10000 samples
+# model: CIFAR10 ResNet18 standard training
+# accuracy: 94.64%
+# attack success rate: 57.53%
+
+# attack type: SpatialTransformAttack2
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                spatial_constraint={'rot': 30, 'trans': 0.10714285714285714}
+#                random_tries=50
+#                attack_type=random
+#                num_rot=31
+#                num_trans=5
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: cifar10_test, 10000 samples
+# model: CIFAR10 ResNet18 standard training
+# accuracy: 94.64%
+# attack success rate: 72.53%
+
+import torch
+import torch.nn as nn
+
+from advertorch_examples.utils import get_mnist_test_loader
+from advertorch_examples.utils import get_mnist_lenet5_clntrained
+from advertorch_examples.utils import get_mnist_lenet5_advtrained
+from advertorch_examples.utils import get_cifar10_test_loader
+from advertorch_examples.utils import get_cifar10_resnet18_clntrained
+from advertorch_examples.benchmark_utils import get_benchmark_sys_info
+
+from advertorch.attacks import SpatialTransformAttack2
+
+from advertorch_examples.benchmark_utils import benchmark_attack_success_rate
+
+batch_size = 100
+if torch.cuda.is_available():
+    device = "cuda"
+else:
+    device = "cpu"
+
+lst_attack = [
+    (SpatialTransformAttack2,
+     dict(loss_fn=nn.CrossEntropyLoss(reduction="sum"),
+          spatial_constraint={'rot': 0.0, 'trans': 0.0},
+          random_tries=1, attack_type='random',
+          num_rot=1, num_trans=1,
+          clip_min=0.0, clip_max=1.0, targeted=False)),
+    (SpatialTransformAttack2,
+     dict(loss_fn=nn.CrossEntropyLoss(reduction="sum"),
+          spatial_constraint={'rot': 30, 'trans': 3 / 28},
+          random_tries=10, attack_type='grid',
+          num_rot=31, num_trans=5,
+          clip_min=0.0, clip_max=1.0, targeted=False)),
+    (SpatialTransformAttack2,
+     dict(loss_fn=nn.CrossEntropyLoss(reduction="sum"),
+          spatial_constraint={'rot': 30, 'trans': 3 / 28},
+          random_tries=10, attack_type='random',
+          num_rot=31, num_trans=5,
+          clip_min=0.0, clip_max=1.0, targeted=False)),
+    (SpatialTransformAttack2,
+     dict(loss_fn=nn.CrossEntropyLoss(reduction="sum"),
+          spatial_constraint={'rot': 30, 'trans': 3 / 28},
+          random_tries=50, attack_type='random',
+          num_rot=31, num_trans=5,
+          clip_min=0.0, clip_max=1.0, targeted=False)),
+]  # each element in the list is the tuple (attack_class, attack_kwargs)
+
+mnist_clntrained_model = get_mnist_lenet5_clntrained(device).to(device)
+mnist_advtrained_model = get_mnist_lenet5_advtrained(device).to(device)
+mnist_test_loader = get_mnist_test_loader(batch_size=batch_size)
+
+cifar10_clntrained_model = get_cifar10_resnet18_clntrained(device)
+cifar10_test_loader = get_cifar10_test_loader(batch_size=batch_size)
+
+lst_setting = [
+    (mnist_clntrained_model, mnist_test_loader),
+    (mnist_advtrained_model, mnist_test_loader),
+    # (cifar10_clntrained_model, cifar10_test_loader),  # need trained model
+]
+
+info = get_benchmark_sys_info()
+
+lst_benchmark = []
+for model, loader in lst_setting:
+    for attack_class, attack_kwargs in lst_attack:
+        lst_benchmark.append(benchmark_attack_success_rate(
+            model, loader, attack_class, attack_kwargs, device=device))
+
+print(info)
+for item in lst_benchmark:
+    print(item)

--- a/advertorch_examples/model_resnet.py
+++ b/advertorch_examples/model_resnet.py
@@ -1,0 +1,115 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class BasicBlock(nn.Module):
+    expansion = 1
+
+    def __init__(self, in_planes, planes, stride=1):
+        super(BasicBlock, self).__init__()
+        self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=3, stride=stride, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+
+        self.shortcut = nn.Sequential()
+        if stride != 1 or in_planes != self.expansion * planes:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(in_planes, self.expansion * planes, kernel_size=1, stride=stride, bias=False),
+                nn.BatchNorm2d(self.expansion * planes)
+            )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out += self.shortcut(x)
+        out = F.relu(out)
+        return out
+
+
+class Bottleneck(nn.Module):
+    expansion = 4
+
+    def __init__(self, in_planes, planes, stride=1):
+        super(Bottleneck, self).__init__()
+        self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, stride=stride, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+        self.conv3 = nn.Conv2d(planes, self.expansion * planes, kernel_size=1, bias=False)
+        self.bn3 = nn.BatchNorm2d(self.expansion * planes)
+
+        self.shortcut = nn.Sequential()
+        if stride != 1 or in_planes != self.expansion * planes:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(in_planes, self.expansion * planes, kernel_size=1, stride=stride, bias=False),
+                nn.BatchNorm2d(self.expansion * planes)
+            )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = F.relu(self.bn2(self.conv2(out)))
+        out = self.bn3(self.conv3(out))
+        out += self.shortcut(x)
+        out = F.relu(out)
+        return out
+
+
+class ResNet(nn.Module):
+    def __init__(self, block, num_blocks, num_classes=10):
+        super(ResNet, self).__init__()
+        self.in_planes = 64
+
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(64)
+        self.layer1 = self._make_layer(block, 64, num_blocks[0], stride=1)
+        self.layer2 = self._make_layer(block, 128, num_blocks[1], stride=2)
+        self.layer3 = self._make_layer(block, 256, num_blocks[2], stride=2)
+        self.layer4 = self._make_layer(block, 512, num_blocks[3], stride=2)
+        self.linear = nn.Linear(512 * block.expansion, num_classes)
+
+    def _make_layer(self, block, planes, num_blocks, stride):
+        strides = [stride] + [1] * (num_blocks - 1)
+        layers = []
+        for stride in strides:
+            layers.append(block(self.in_planes, planes, stride))
+            self.in_planes = planes * block.expansion
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.layer1(out)
+        out = self.layer2(out)
+        out = self.layer3(out)
+        out = self.layer4(out)
+        out = F.avg_pool2d(out, 4)
+        out = out.view(out.size(0), -1)
+        out = self.linear(out)
+        return out
+
+
+def ResNet18():
+    return ResNet(BasicBlock, [2, 2, 2, 2])
+
+
+def ResNet34():
+    return ResNet(BasicBlock, [3, 4, 6, 3])
+
+
+def ResNet50():
+    return ResNet(Bottleneck, [3, 4, 6, 3])
+
+
+def ResNet101():
+    return ResNet(Bottleneck, [3, 4, 23, 3])
+
+
+def ResNet152():
+    return ResNet(Bottleneck, [3, 8, 36, 3])
+
+
+def test():
+    net = ResNet18()
+    y = net(torch.randn(1, 3, 32, 32))
+    print(y.size())

--- a/advertorch_examples/utils.py
+++ b/advertorch_examples/utils.py
@@ -21,6 +21,7 @@ import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 
 from advertorch.test_utils import LeNet5
+from advertorch_examples.model_resnet import ResNet18
 
 # TODO: need to refactor path to keep a single copy of file
 
@@ -71,25 +72,40 @@ def get_cifar10_test_loader(batch_size, shuffle=False):
     return loader
 
 
-def get_mnist_lenet5_clntrained():
+def get_mnist_lenet5_clntrained(device='cuda'):
     filename = "mnist_lenet5_clntrained.pt"
-    model = LeNet5()
+    model = LeNet5().to(device)
     model.load_state_dict(
-        torch.load(os.path.join(TRAINED_MODEL_PATH, filename)))
+        torch.load(os.path.join(TRAINED_MODEL_PATH, filename),
+                   map_location=torch.device(device)))
     model.eval()
     model.name = "MNIST LeNet5 standard training"
     # TODO: also described where can you find this model, and how is it trained
     return model
 
 
-def get_mnist_lenet5_advtrained():
+def get_mnist_lenet5_advtrained(device='cuda'):
     filename = "mnist_lenet5_advtrained.pt"
-    model = LeNet5()
+    model = LeNet5().to(device)
     model.load_state_dict(
-        torch.load(os.path.join(TRAINED_MODEL_PATH, filename)))
+        torch.load(os.path.join(TRAINED_MODEL_PATH, filename),
+                   map_location=torch.device(device)))
     model.eval()
+    model = model.to(device)
     model.name = "MNIST LeNet 5 PGD training according to Madry et al. 2018"
     # TODO: also described where can you find this model, and how is it trained
+    return model
+
+
+def get_cifar10_resnet18_clntrained(device='cuda'):
+    filename = "cifar10_resnet18_clntrained.pt"
+    model = ResNet18()
+    model.load_state_dict(
+        torch.load(os.path.join(TRAINED_MODEL_PATH, filename),
+                   map_location=torch.device(device)))
+    model.eval()
+    model = model.to(device)
+    model.name = "CIFAR10 ResNet18 standard training"
     return model
 
 

--- a/tests/test_attacks_running.py
+++ b/tests/test_attacks_running.py
@@ -32,6 +32,7 @@ from advertorch.attacks import ElasticNetL1Attack
 from advertorch.attacks import LBFGSAttack
 from advertorch.attacks import JacobianSaliencyMapAttack
 from advertorch.attacks import SpatialTransformAttack
+from advertorch.attacks import SpatialTransformAttack2
 from advertorch.attacks import LinfSPSAAttack
 from advertorch.attacks import LinfFABAttack
 from advertorch.attacks import L2FABAttack
@@ -89,6 +90,9 @@ attack_kwargs = {
     LBFGSAttack: {"num_classes": NUM_CLASS},
     JacobianSaliencyMapAttack: {"num_classes": NUM_CLASS, "gamma": 0.01},
     SpatialTransformAttack: {"num_classes": NUM_CLASS},
+    SpatialTransformAttack2: {
+        "spatial_constraint": {'rot': 30, 'trans': 3 / 28}, "random_tries": 10,
+        "attack_type": 'random'},
     DDNL2Attack: {"nb_iter": 5},
     LinfSPSAAttack: {"eps": 0.3, "max_batch_size": 63},
     LinfFABAttack: {"n_iter": 5},


### PR DESCRIPTION
Add a simple spatial transform attack was proposed at [ICML2019](http://proceedings.mlr.press/v97/engstrom19a.html).

I benchmarked with mnist and cifar10.
I didn't include the cifar10 trained model by resnet18 in the repository because it had 43MB (Please comment if you need to.).
It was a stronger attack in mnist than the original paper and a weaker attack in cifar10.

In the original repository, mnist and cifar10 are implemented tensorflow and imagenet is implemented PyTorch.
I used the implementation for [imagenet implemented in Pytorch](https://github.com/MadryLab/spatial-pytorch/blob/master/robustness/spatial.py#L62), since the spatial transformation was dependent on [tensorflow functions](https://github.com/MadryLab/adversarial_spatial/blob/master/resnet.py#L47).
These spatial transformations didn't match numerically, but they appear to be nearly identical in appearance.
![image](https://user-images.githubusercontent.com/8328986/88007899-f0ba1700-cb49-11ea-8334-46a11f7c67a5.png)

The original implementation of cifar10 had a [standardized layer](https://github.com/MadryLab/adversarial_spatial/blob/master/resnet.py#L53) attached to the model, but my implementation didn't standardize it.

The pytest on the GPU had some errors before the change and I ignored them.